### PR TITLE
fixed BinaryActioWrapper

### DIFF
--- a/craftium/wrappers.py
+++ b/craftium/wrappers.py
@@ -66,8 +66,8 @@ class BinaryActionWrapper(ActionWrapper):
 
     def action(self, action):
         if isinstance(action, list) or isinstance(action, np.ndarray):
-            return [self.process(act) for act in action]
-        return self.process(action)
+            return self.process(action)
+        return self.process([action])
 
 
 class DiscreteActionWrapper(ActionWrapper):


### PR DESCRIPTION
Fixed a bug in BinaryActionWrapper that appeared when performing a step. Instead of processing the list of actions as a whole, each action was processed separately which caused the next error:

TypeError                                 Traceback (most recent call last)
Cell In[19], line 12
     10 for i in range(iters):
     11     action = env.action_space.sample()
---> 12     observation, reward, terminated, truncated, _info = env.step(action)


File gymnasium/core.py:591, in ActionWrapper.step(self, action)
    587 def step(
    588     self, action: WrapperActType
    589 ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
    590     """Runs the :attr:`env` :meth:`env.step` using the modified ``action`` from :meth:`self.action`."""
--> 591     return self.env.step(self.action(action))

File craftium/wrappers.py:69, in BinaryActionWrapper.action(self, action)
     67 def action(self, action):
     68     if isinstance(action, list) or isinstance(action, np.ndarray):
---> 69         return [self.process(act) for act in action]
     70     return self.process(action)

File craftium/wrappers.py:43, in BinaryActionWrapper.process(self, action)
     42 def process(self, action):
---> 43     assert len(action) == len(self.actions), \
     44         f"Incorrect number of actions, got {len(action)} but expected {len(self.actions)}"
     46     res = {}
     47     mouse = [0, 0]

TypeError: object of type 'numpy.int8' has no len()

